### PR TITLE
Fix program name when printing error

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -36,10 +36,10 @@ zopen_check_results()
 #Testsuite summary for man-db 2.10.2
 #============================================================================
 # TOTAL: 31
-# PASS:  29
+# PASS:  30
 # SKIP:  0
 # XFAIL: 0
-# FAIL:  2
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0
   dir="$1"
@@ -48,7 +48,7 @@ zopen_check_results()
 
   totalTests=$(grep '# TOTAL:' $chk | awk '{ print $3 }')
   actualFailures=$(grep '# FAIL:' $chk | awk '{ print $3 }')
-  expectedFailures=2
+  expectedFailures=1
   echo "actualFailures:${actualFailures}"
   echo "totalTests:${totalTests}"
   echo "expectedFailures:${expectedFailures}"

--- a/patches/getprogname.c.patch
+++ b/patches/getprogname.c.patch
@@ -1,0 +1,18 @@
+diff --git a/gl/lib/getprogname.c b/gl/lib/getprogname.c
+index 62a4800..b3986db 100644
+--- a/gl/lib/getprogname.c
++++ b/gl/lib/getprogname.c
+@@ -213,8 +213,12 @@ getprogname (void)
+               if (token > 0 && buf.ps_pid == pid)
+                 {
+                   char *s = strdup (last_component (buf.ps_pathptr));
+-                  if (s)
++                  if (s) {
+                     p = s;
++#if (__CHARSET_LIB == 1)
++                    __e2a_s(p);
++#endif
++                  }
+                   break;
+                 }
+             }

--- a/patches/getprogname.h.patch
+++ b/patches/getprogname.h.patch
@@ -1,0 +1,22 @@
+diff --git a/gl/lib/getprogname.h b/gl/lib/getprogname.h
+index 9a35e58..f61ee97 100644
+--- a/gl/lib/getprogname.h
++++ b/gl/lib/getprogname.h
+@@ -23,6 +23,9 @@
+ extern "C" {
+ #endif
+ 
++#ifdef __MVS__
++  extern char const *getprogname (void);
++#else
+ /* Return the base name of the executing program.
+    On native Windows this will usually end in ".exe" or ".EXE". */
+ #ifndef HAVE_GETPROGNAME
+@@ -32,6 +35,7 @@ extern char const *getprogname (void)
+ # endif
+   ;
+ #endif
++#endif
+ 
+ #ifdef __cplusplus
+ }


### PR DESCRIPTION
There were 2 problems:
- the prototype for the getprogname() function was not being pulled in due to some funny configuration issues. Temporarily added #ifdef __MVS__ to get the prototype
- the code behind getprogname() was surfacing an internal string that was EBCDIC, so it needed to be converted to ASCII