### PR TITLE
Allow .o objects to be passed through via configure

### DIFF
--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,8 +1,19 @@
 diff --git a/configure b/configure
-index 9c7e356..294fd14 100755
+index 9c7e356..9ab53d5 100755
 --- a/configure
 +++ b/configure
-@@ -18715,10 +18715,7 @@ if test ${man_cv_prog_gnu_nroff+y}
+@@ -11573,6 +11573,10 @@ aix[4-9]*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
++openedition)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
+ beos*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+@@ -18715,10 +18719,7 @@ if test ${man_cv_prog_gnu_nroff+y}
  then :
    printf %s "(cached) " >&6
  else $as_nop


### PR DESCRIPTION
This allows the zoslib_env_hook.o to be passed through. Other platforms like aix, etc are enabling this by default as well.