### PR TITLE
Remove absolute directory. Improve failure checking to create failures file

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -47,8 +47,14 @@ zopen_check_results()
   chk="$1/$2_check.log"
 
   totalTests=$(grep '# TOTAL:' $chk | awk '{ print $3 }')
-  actualFailures=$(grep '# FAIL:' $chk | awk '{ print $3 }')
-  expectedFailures=1
+  failureTests=$(grep -e '^FAIL:' $chk)
+  if [ "${failureTests}x" = "x" ]; then
+    actualFailures=0
+  else
+    actualFailures=$(echo "${failureTests}" | wc -l)
+  fi
+  expectedFailures=2
+  echo "${failureTests}" >"$1/$2_check_failures.log"
   echo "actualFailures:${actualFailures}"
   echo "totalTests:${totalTests}"
   echo "expectedFailures:${expectedFailures}"
@@ -56,7 +62,7 @@ zopen_check_results()
 
 zopen_append_to_env() {
 cat <<EOF
-# temporary 
+# temporary
 export MAN_TEST_DISABLE_SYSTEM_CONFIG=1
 EOF
 }

--- a/patches/Makefile.in.patch
+++ b/patches/Makefile.in.patch
@@ -1,0 +1,21 @@
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 0f13f6c..bf0b80a 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -1738,12 +1738,12 @@ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/lib \
+ 	-I$(top_srcdir)/libdb \
+ 	-DCONFIG_FILE=\"$(config_file)\" \
+-	-DAPROPOS=\"$(bindir)/$(TRANS_APROPOS)\" \
++	-DAPROPOS=\"$(TRANS_APROPOS)\" \
+ 	-DAPROPOS_NAME=\"$(TRANS_APROPOS)\" \
+-	-DMAN=\"$(bindir)/$(TRANS_MAN)\" \
++	-DMAN=\"$(TRANS_MAN)\" \
+ 	-DMANCONV=\"$(pkglibexecdir)/$(TRANS_MANCONV)\" \
+-	-DMANDB=\"$(bindir)/$(TRANS_MANDB)\" \
+-	-DWHATIS=\"$(bindir)/$(TRANS_WHATIS)\" \
++	-DMANDB=\"$(TRANS_MANDB)\" \
++	-DWHATIS=\"$(TRANS_WHATIS)\" \
+ 	-DZSOELIM=\"$(pkglibexecdir)/$(TRANS_ZSOELIM)\"
+ 
+ AM_CFLAGS = \


### PR DESCRIPTION
Note number of 'failures' went up by 1, but I don't believe it did since it is calling 'seq' as a core tool which fails 
so the 'pass' was a false pass in the past.