### PR TITLE
Remove environment variables as they are no longer needed

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -59,13 +59,6 @@ zopen_check_results()
   echo "expectedFailures:${expectedFailures}"
 }
 
-zopen_append_to_env() {
-cat <<EOF
-# temporary
-export MAN_TEST_DISABLE_SYSTEM_CONFIG=1
-EOF
-}
-
 zopen_append_to_zoslib_env() {
 cat <<EOF
 MAN_TEST_DISABLE_SYSTEM_CONFIG|set|1


### PR DESCRIPTION
As they are set implicitly via zopen_append_to_zoslib_env