### PR TITLE
Fix additional tests

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -11,6 +11,7 @@ export ZOPEN_EXTRA_CONFIGURE_OPTS='--disable-cache-owner'
 export LESSCHARSET=utf-8
 export ZOPEN_RUNTIME_DEPS="groff libiconv less ncurses"
 export ZOPEN_COMP="CLANG"
+export ZOPEN_CHECK_OPTS="-i check"
 
 rm -f patches
 if [ "${ZOPEN_BUILD_LINE}x" = "STABLEx" ]; then
@@ -27,34 +28,26 @@ else
   export libpipeline_LIBS="-lpipeline"
 fi
 
+zopen_pre_check() {
+  # z/OS Open Tools MANPATH can cause "cannot execute: EDC5126I Filename too long." in libtool
+  unset MANPATH
+}
+
 zopen_check_results()
 {
-#============================================================================
-#Testsuite summary for man-db 2.10.2
-#============================================================================
-# TOTAL: 32
-# PASS:  30
-# SKIP:  0
-# XFAIL: 0
-# FAIL:  2
-# XPASS: 0
-# ERROR: 0
   dir="$1"
   pfx="$2"
   chk="$1/$2_check.log"
 
-  totalTests=$(grep '# TOTAL:' $chk | awk '{ print $3 }')
-  failureTests=$(grep -e '^FAIL:' $chk)
-  if [ "${failureTests}x" = "x" ]; then
-    actualFailures=0
-  else
-    actualFailures=$(echo "${failureTests}" | wc -l)
-  fi
-  expectedFailures=2
-  echo "${failureTests}" >"$1/$2_check_failures.log"
-  echo "actualFailures:${actualFailures}"
-  echo "totalTests:${totalTests}"
-  echo "expectedFailures:${expectedFailures}"
+  # We only care about the summary as man's test results display FAILS duplicate times in the same format
+  failures=$(grep -A 10 "Testsuite summary for man-db"  ${chk} | grep -E '^# FAIL:|^# ERROR:|^# XFAIL' | awk '{sum+=$3;} END{print sum;}')
+  totalTests=$(grep -A 10 "Testsuite summary for man-db"  ${chk} | grep -E '^# ERROR:|^# PASS:|^# XFAIL:|^# FAIL:|^# XPASS:' | awk '{sum+=$3;} END{print sum;}')
+
+  cat <<ZZ
+  actualFailures:$failures
+  totalTests:$totalTests
+  expectedFailures:12
+ZZ
 }
 
 zopen_append_to_zoslib_env() {

--- a/tarball-patches/man.c.patch
+++ b/tarball-patches/man.c.patch
@@ -1,14 +1,15 @@
 diff --git a/src/man.c b/src/man.c
-index f072c75..dd51448 100644
+index 5d3be39..6d71087 100644
 --- a/src/man.c
 +++ b/src/man.c
-@@ -4440,7 +4440,25 @@ int main (int argc, char *argv[])
+@@ -4479,8 +4479,25 @@ int main (int argc, char *argv[])
  					if (!section && maybe_section &&
  					    CTYPE (isdigit, nextarg[0]))
  						gripe_no_name (nextarg);
 -					else
+-						gripe_no_man (nextarg, section);
 +					else {
-+#ifdef __MVS__
++#if __MVS__
 +            char* fmt = "/bin/man %s %s 2>/dev/null";
 +            char* cmd = malloc(strlen(nextarg)+strlen(section)+strlen(fmt)+1);
 +            int rc = 0;
@@ -26,6 +27,6 @@ index f072c75..dd51448 100644
 +#else
 +					gripe_no_man (nextarg, section);
 +#endif
- 						gripe_no_man (nextarg, section);
  				}
  			}
+ 		} else {


### PR DESCRIPTION
* This fixes two additional tests which results in the first set of tests now completely passing.
* This fixes the duplicate "No manual entry" issue - there was an extra call to gripe_no_man https://github.com/ZOSOpenTools/man-dbport/compare/fix_more_tests?expand=1#diff-8d71d7400911dfb47d851d83a0f5cc613c47ad9d039fed71a66940c4c76f4b50L29
* However, this now means that the next set of tests are run...and unfortunately all fail.
* It also fixes how test results are calculated
* I've also added `-i check` in the event that one of the tests starts regressing

I will open an issue for the new test failures 